### PR TITLE
Fix flawed assumption in includes/excludes predicate

### DIFF
--- a/__tests__/predicate.test.js
+++ b/__tests__/predicate.test.js
@@ -167,6 +167,8 @@ describe('predicate', () => {
       const value2 = ['a', 'b'];
       const value3 = ['c', 'd'];
       const value4 = ['d'];
+      const value5 = 'a';
+      const value6 = 6;
 
       expect(
         predicate(operators.INCLUDES)({ value: value1, other }),
@@ -181,6 +183,13 @@ describe('predicate', () => {
         predicate(operators.INCLUDES)({ value: value4, other }),
       ).toBe(false);
       expect(
+        predicate(operators.INCLUDES)({ value: value5, other }),
+      ).toBe(true);
+      expect(
+        predicate(operators.INCLUDES)({ value: value6, other }),
+      ).toBe(false);
+
+      expect(
         predicate(operators.INCLUDES)({ value: value1, other: other2 }),
       ).toBe(true);
       expect(
@@ -188,6 +197,15 @@ describe('predicate', () => {
       ).toBe(true);
       expect(
         predicate(operators.INCLUDES)({ value: value3, other: other2 }),
+      ).toBe(false);
+      expect(
+        predicate(operators.INCLUDES)({ value: value4, other: other2 }),
+      ).toBe(false);
+      expect(
+        predicate(operators.INCLUDES)({ value: value5, other: other2 }),
+      ).toBe(true);
+      expect(
+        predicate(operators.INCLUDES)({ value: value6, other: other2 }),
       ).toBe(false);
     });
 
@@ -199,6 +217,8 @@ describe('predicate', () => {
       const value2 = ['a', 'b'];
       const value3 = ['a', 'c', 'd'];
       const value4 = ['d'];
+      const value5 = 'a';
+      const value6 = 6;
 
       expect(
         predicate(operators.EXCLUDES)({ value: value1, other }),
@@ -213,6 +233,13 @@ describe('predicate', () => {
         predicate(operators.EXCLUDES)({ value: value4, other }),
       ).toBe(true);
       expect(
+        predicate(operators.EXCLUDES)({ value: value5, other }),
+      ).toBe(false);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value6, other }),
+      ).toBe(true);
+
+      expect(
         predicate(operators.EXCLUDES)({ value: value1, other: other2 }),
       ).toBe(false);
       expect(
@@ -223,6 +250,12 @@ describe('predicate', () => {
       ).toBe(false);
       expect(
         predicate(operators.EXCLUDES)({ value: value4, other: other2 }),
+      ).toBe(true);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value5, other: other2 }),
+      ).toBe(false);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value6, other: other2 }),
       ).toBe(true);
     });
 

--- a/predicate.js
+++ b/predicate.js
@@ -78,11 +78,21 @@ const predicate = operator =>
       }
       case operators.INCLUDES: {
         if (!value) { return false; } // ord/cat vars are initialised to null
-        return value.some(v => other.includes(v));
+
+        if (isArray(value)) {
+          return value.some(v => other.includes(v));
+        }
+
+        return other.includes(value);
       }
       case operators.EXCLUDES: {
         if (!value) { return true; } // ord/cat vars are initialised to null
-        return !value.some(v => other.includes(v));
+
+        if (isArray(value)) {
+          return !value.some(v => other.includes(v));
+        }
+
+        return !other.includes(value);
       }
       case operators.EXISTS:
         return !isNull(value);


### PR DESCRIPTION
Fixes an issue caused by the assumption that ordinal/categorical node values are always arrays. In fact they can be strings when a single value is assigned on categorical/ordinal bin interface.

This commit fixes the issue by checking if the value is an array before calling array specific methods such as `.some()`.

Adds test coverage for the scenario where values are strings or numbers.